### PR TITLE
Added css class to the portfolio columns to align items

### DIFF
--- a/src/modules/portfolio/components/Portfolio.vue
+++ b/src/modules/portfolio/components/Portfolio.vue
@@ -8,7 +8,7 @@
                         | You have no shares right now. Buy some on the 
                         router-link(to="/stocks") market.
             div(v-else)
-                div.columns
+                div.columns.is-multiline
                     div.column.is-half(v-for="asset in items")
                         asset(
                             :name="asset.name", 


### PR DESCRIPTION
Class "is-multiline" is added to the columns in the Portfolio.vue component for the adding flex-wrap: wrap when a few items selected.

@sarneeh  please take a look at the screen
![portfolio-items](https://user-images.githubusercontent.com/10995658/103742494-93d0f100-5003-11eb-9517-806dc1e27260.png)
